### PR TITLE
Hotfix/get adf15 output

### DIFF
--- a/backend/OpenADAS/get_adf15.py
+++ b/backend/OpenADAS/get_adf15.py
@@ -146,10 +146,25 @@ def get_adf15(
         visible: bool = True
     ) -> str:
     """
-    Download OpenADAS ADF15 library.
+    Download adf15 files from the OpenADAS library. Typically, adf15 files will contain excitation and recombination
+    PECs. In somes cases there will
 
+    Examples:
+        - C III PECs `adf15: str = get_adf15(element='c', charge=2)`
+        - Ne III PECs `adf15: str = get_adf15(element='ne', charge=2)`
+        - H I PECs `adf15: str = get_adf15(element='h', charge=0, year=12)`
 
-    :return:
+    :param (str) element:
+        Element abbreviation for the requested data (lower case). For example hydrogen is 'h' and lithium is 'li'.
+    :param (int) charge:
+        Charge state of the ion whose PECs are wanted.
+    :param (int) year: 96
+        Reference year for the data. Most ADF11 files will have year 93 and 96 versions. Broadly the newer data is
+        "better" as it is created to overcome limitations in the older data.
+    :param (bool) resolved: False
+    :param (bool) visible: True
+    :return (str) adf15:
+        The adf11 file downloaded as a string
     """
     # Format inputs
     resolution: str = 'r' if resolved else 'u'

--- a/backend/OpenADAS/get_adf15.py
+++ b/backend/OpenADAS/get_adf15.py
@@ -144,7 +144,7 @@ def get_adf15(
         year: int = 96,
         resolved: bool = False,
         visible: bool = True
-    ) -> None:
+    ) -> str:
     """
     Download OpenADAS ADF15 library.
 
@@ -158,9 +158,9 @@ def get_adf15(
     download_url: str = f'https://open.adas.ac.uk/download/adf15/pec{year}][{element}/pec{year}][{element}_{visible}{resolution}][{element}{charge}.dat'
     # Download
     with request.urlopen(download_url) as f:
-        _: str = f.read().decode('utf-8')
+        adf15: str = f.read().decode('utf-8')
 
-    pass
+    return adf15
 
 
 def main() -> None:

--- a/tests/OpenADAS/test_get_adf11.py
+++ b/tests/OpenADAS/test_get_adf11.py
@@ -1,0 +1,33 @@
+# Imports
+from backend.OpenADAS import get_adf11
+
+
+# Variables
+
+
+# Functions and classes
+class TestGetAdf11:
+
+    def test_one(self) -> None:
+        adf11: str = get_adf11(element='h', adf11type='acd', year=12)
+        assert type(adf11) is str
+
+    def test_two(self) -> None:
+        adf11: str = get_adf11(element='li', adf11type='scd', year=93, resolved=True)
+        assert type(adf11) is str
+
+    def test_three(self) -> None:
+        adf11: str = get_adf11(element='c', adf11type='ccd', resolved=True)
+        assert type(adf11) is str
+
+    def test_four(self) -> None:
+        adf11: str = get_adf11(element='n', adf11type='scd')
+        assert type(adf11) is str
+
+
+def main() -> None:
+    pass
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/OpenADAS/test_get_adf15.py
+++ b/tests/OpenADAS/test_get_adf15.py
@@ -1,30 +1,11 @@
 # Imports
-from backend.OpenADAS import get_adf11, get_adf15, list_adf15s
+from backend.OpenADAS import get_adf15, list_adf15s
 
 
 # Variables
 
 
 # Functions and classes
-class TestGetAdf11:
-
-    def test_one(self) -> None:
-        adf11: str = get_adf11(element='h', adf11type='acd', year=12)
-        assert type(adf11) is str
-
-    def test_two(self) -> None:
-        adf11: str = get_adf11(element='li', adf11type='scd', year=93, resolved=True)
-        assert type(adf11) is str
-
-    def test_three(self) -> None:
-        adf11: str = get_adf11(element='c', adf11type='ccd', resolved=True)
-        assert type(adf11) is str
-
-    def test_four(self) -> None:
-        adf11: str = get_adf11(element='n', adf11type='scd')
-        assert type(adf11) is str
-
-
 class TestGetAdf15:
 
     def test_C_III(self):

--- a/tests/test_OpenADAS.py
+++ b/tests/test_OpenADAS.py
@@ -28,22 +28,16 @@ class TestGetAdf11:
 class TestGetAdf15:
 
     def test_C_III(self):
-        element: str = 'c'
-        charge: int = 2
-        get_adf15(element, charge)
-        assert True
+        adf15: str = get_adf15(element='c', charge=2)
+        assert type(adf15) is str
 
     def test_Ne_III(self):
-        element: str = 'ne'
-        charge: int = 2
-        get_adf15(element, charge)
-        assert True
+        adf15: str = get_adf15(element='ne', charge=2)
+        assert type(adf15) is str
 
     def test_H_I(self):
-        element: str = 'h'
-        charge: int = 0
-        get_adf15(element, charge, year=12)
-        assert True
+        adf15: str = get_adf15(element='h', charge=0, year=12)
+        assert type(adf15) is str
 
 
 class TestListAdf15s:


### PR DESCRIPTION
Changes:
 - `get_adf15` now has the adf15 file as an output (string)
 - Added a doc string to `get_adf15`
 - Broken up pytests for OpenADAS API for readability of the pytest runs